### PR TITLE
Fixed apiVersion for NetworkPolicy

### DIFF
--- a/deploy.yaml
+++ b/deploy.yaml
@@ -86,7 +86,7 @@ spec:
   type: ClusterIP
 ---
 
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   labels:


### PR DESCRIPTION
When deploying on **K8S v1.18.0** it breaks with the following error:
`error: unable to recognize "https://raw.githubusercontent.com/scholzj/zoo-entrance/master/deploy.yaml": no matches for kind "NetworkPolicy" in version "extensions/v1beta1"`

The API "extensions/v1beta1" is deprecated: [kubernetes.io/blog](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/)

Fixed due to adding "_networking.k8s.io/v1_" as apiVersion