### PR TITLE
Update to Strimzi 0.26.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/strimzi/kafka:0.26.0-kafka-3.0.0
+FROM quay.io/strimzi/kafka:0.26.1-kafka-3.0.0
 
 LABEL org.opencontainers.image.source https://github.com/scholzj/zoo-entrance \
       summary="Zoo Entrance" \


### PR DESCRIPTION
Bump image to Strimzi 0.26.1 which has been patched for log4j CVE